### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Krkn aka Kraken
-[![Docker Repository on Quay](https://quay.io/repository/chaos-kubox/krkn?tab=tags&tag=latest "Docker Repository on Quay")](https://quay.io/chaos-kubox/krkn)
+[![Docker Repository on Quay](https://quay.io/repository/chaos-kubox/krkn/status "Docker Repository on Quay")](https://quay.io/repository/chaos-kubox/krkn?tab=tags&tag=latest)
 
 ![Krkn logo](media/logo.png)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Kraken injects deliberate failures into Kubernetes/OpenShift clusters to check i
 - Test environment recommendations as to how and where to run chaos tests.
 - Chaos testing in practice.
 
-The guide is hosted at [https://chaos-kubox.github.io/krkn/](https://chaos-kubox.github.io/krkn/).
+The guide is hosted at https://redhat-chaos.github.io/krkn.
 
 
 ### How to Get Started


### PR DESCRIPTION
Change the guide link to new subdomain.

Fix the Quay.io status badge. The status currently says "none". I'm unsure if that's because the repo on Quay doesn't have any automated builds or if Quay is having issues. It might be better to just make a custom badge like this:

[![Docker Repository on Quay](https://img.shields.io/badge/container-latest-success "Docker Repository on Quay")](https://quay.io/repository/chaos-kubox/krkn?tab=tags&tag=latest)
