### PR TITLE
Create prometheus token to use for OCP versions >=4.11

### DIFF
--- a/kraken/prometheus/client.py
+++ b/kraken/prometheus/client.py
@@ -9,5 +9,8 @@ def instance(distribution, prometheus_url, prometheus_bearer_token):
         )
         prometheus_url = "https://" + url
     if distribution == "openshift" and not prometheus_bearer_token:
-        prometheus_bearer_token = runcommand.invoke("oc -n openshift-monitoring " "sa get-token prometheus-k8s")
+        prometheus_bearer_token = runcommand.invoke(
+            "oc -n openshift-monitoring sa get-token prometheus-k8s "
+            "|| oc create token -n openshift-monitoring prometheus-k8s"
+        )
     return prometheus_url, prometheus_bearer_token


### PR DESCRIPTION
This commit adopts the code from https://github.com/redhat-chaos/cerberus/pull/176
to support using the existing/creating new token needed to query prometheus depending
on the OpenShift version in use.

Co-authored-by: Paige Rubendall <prubenda@redhat.com>