### PR TITLE
Add option to skip litmus installation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,7 @@ kraken:
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
+    litmus_install: True                                   # Installs specified version, set to False if it's already setup
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     litmus_uninstall_before_run: True                      # If you want to uninstall litmus before a new run starts

--- a/config/config_kubernetes.yaml
+++ b/config/config_kubernetes.yaml
@@ -5,6 +5,7 @@ kraken:
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
+    litmus_install: True                                   # Installs specified version, set to False if it's already setup
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     litmus_uninstall_before_run: True                      # If you want to uninstall litmus before a new run starts

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -47,6 +47,7 @@ def main(cfg):
         publish_running_status = config["kraken"].get("publish_kraken_status", False)
         port = config["kraken"].get("port", "8081")
         run_signal = config["kraken"].get("signal_state", "RUN")
+        litmus_install = config["kraken"].get("litmus_install", True)
         litmus_version = config["kraken"].get("litmus_version", "v1.9.1")
         litmus_uninstall = config["kraken"].get("litmus_uninstall", False)
         litmus_uninstall_before_run = config["kraken"].get("litmus_uninstall_before_run", True)
@@ -130,7 +131,6 @@ def main(cfg):
             iterations = int(iterations)
 
         failed_post_scenarios = []
-        litmus_installed = False
 
         # Capture the start time
         start_time = int(time.time())
@@ -189,7 +189,7 @@ def main(cfg):
                             if distribution == "openshift":
                                 logging.info("Running litmus scenarios")
                                 litmus_namespace = "litmus"
-                                if not litmus_installed:
+                                if litmus_install:
                                     # Remove Litmus resources before running the scenarios
                                     common_litmus.delete_chaos(litmus_namespace)
                                     common_litmus.delete_chaos_experiments(litmus_namespace)
@@ -197,7 +197,6 @@ def main(cfg):
                                         common_litmus.uninstall_litmus(litmus_version, litmus_namespace)
                                     common_litmus.install_litmus(litmus_version, litmus_namespace)
                                     common_litmus.deploy_all_experiments(litmus_version, litmus_namespace)
-                                    litmus_installed = True
                                     common_litmus.run(
                                         scenarios_list,
                                         config,


### PR DESCRIPTION
This commit adds an option for the user to pick whether to install
litmus or not depending on their use case. One use case is disconnected
environments where litmus is pre-installed insted of reaching out to the
internet.