### PR TITLE
config: really default to ~ instead of /root

### DIFF
--- a/CI/config/common_test_config.yaml
+++ b/CI/config/common_test_config.yaml
@@ -1,6 +1,6 @@
 kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift.
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig.
+    kubeconfig_path: ~/.kube/config                        # Path to kubeconfig.
     exit_on_failure: False                                 # Exit when a post action scenario fails.
     litmus_version: v1.13.6                                # Litmus version to install.
     litmus_uninstall: False                                # If you want to uninstall litmus if failure.

--- a/ansible/vars/kraken_vars.yml
+++ b/ansible/vars/kraken_vars.yml
@@ -8,13 +8,13 @@ orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true
 ###############################################################################
 
 # kube config location
-kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('/root/.kube/config', true) }}"
+kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('~/.kube/config', true) }}"
 
 # kraken dir location on jump host
-kraken_dir: "{{ lookup('env', 'KRAKEN_DIR')|default('/root/kraken', true) }}"
+kraken_dir: "{{ lookup('env', 'KRAKEN_DIR')|default('~/kraken', true) }}"
 
 # kraken config path location
-kraken_config: "{{ lookup('env', 'KRAKEN_CONFIG')|default('/root/kraken/config/config.yaml', true) }}"
+kraken_config: "{{ lookup('env', 'KRAKEN_CONFIG')|default('~/kraken/config/config.yaml', true) }}"
 
 # kraken repository location
 kraken_repository: "{{ lookup('env', 'KRAKEN_REPOSITORY')|default('https://github.com/openshift-scale/kraken.git', true) }}"

--- a/config/cerberus.yaml
+++ b/config/cerberus.yaml
@@ -1,6 +1,6 @@
 cerberus:
     distribution: openshift                              # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                  # Path to kubeconfig
+    kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     port: 8080                                           # http server port where cerberus status is published
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
+    kubeconfig_path: ~/.kube/config                        # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081

--- a/config/config_kubernetes.yaml
+++ b/config/config_kubernetes.yaml
@@ -1,6 +1,6 @@
 kraken:
-    distribution: kubernetes                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
+    distribution: kubernetes                               # Distribution can be kubernetes or openshift
+    kubeconfig_path: ~/.kube/config                        # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -1,6 +1,6 @@
 kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
+    kubeconfig_path: ~/.kube/config                        # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081

--- a/docs/network_chaos.md
+++ b/docs/network_chaos.md
@@ -1,7 +1,7 @@
 ### Network chaos
 Scenario to introduce network latency, packet loss, and bandwidth restriction in the Node's host network interface. The purpose of this scenario is to observe faults caused by random variations in the network.
 
-##### Sample scenario config for egress traffic shaping 
+##### Sample scenario config for egress traffic shaping
 ```
 network_chaos:                                    # Scenario to create an outage by simulating random variations in the network.
   duration: 300                                   # In seconds - duration network chaos will be applied.
@@ -20,18 +20,18 @@ network_chaos:                                    # Scenario to create an outage
 ##### Sample scenario config for ingress traffic shaping (using a plugin)
 '''
 - id: network_chaos
-  config: 
+  config:
     node_interface_name:                            # Dictionary with key as node name(s) and value as a list of its interfaces to test
       ip-10-0-128-153.us-west-2.compute.internal:
         - ens5
         - genev_sys_6081
     label_selector: node-role.kubernetes.io/master  # When node_interface_name is not specified, nodes with matching label_selector is selected for node chaos scenario injection
     instance_count: 1                               # Number of nodes to perform action/select that match the label selector
-    kubeconfig_path: /root/.kube/config             # Path to kubernetes config file. If not specified, it defaults to ~/.kube/config
+    kubeconfig_path: ~/.kube/config                 # Path to kubernetes config file. If not specified, it defaults to ~/.kube/config
     execution_type: parallel                        # Execute each of the ingress options as a single scenario(parallel) or as separate scenario(serial).
     network_params:
-        latency: 50ms                    
-        loss: '0.02'                       
+        latency: 50ms
+        loss: '0.02'
         bandwidth: 100mbit
     wait_duration: 120
     test_duration: 60

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -43,7 +43,7 @@ def main(cfg):
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
-        kubeconfig_path = config["kraken"].get("kubeconfig_path", "")
+        kubeconfig_path = os.path.expanduser(config["kraken"].get("kubeconfig_path", ""))
         chaos_scenarios = config["kraken"].get("chaos_scenarios", [])
         publish_running_status = config["kraken"].get(
             "publish_kraken_status", False


### PR DESCRIPTION
Documentation says we default to ~ for looking up the kubernetes config but then we set everywhere /root. Fixed the config to really look for ~.

Should solve #327.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>