### PR TITLE
Update kraken.yml

### DIFF
--- a/containers/kraken.yml
+++ b/containers/kraken.yml
@@ -24,7 +24,7 @@ spec:
               name: config
             - mountPath: "/root/kraken/config"
               name: kraken-config
-            - mountPath: "/root/kraken/scenarios"
+            - mountPath: "/root/kraken/scenarios/openshift"
               name: scenarios-config
             - mountPath: "/root/kraken/scenarios/openshift"
               name: scenarios-openshift-config


### PR DESCRIPTION
This fixes https://github.com/redhat-chaos/krkn/issues/338

Changing the `mountPath` to map to a folder to the location specified in the `config.yaml` example file which references `scenarios/openshift/<scenario.yaml>` so that the example files can be stream lined.

Tested on OpenShift 4.10.28

Signed-off-by: stratus-ss <steve.ovens@x86innovations.com>