### PR TITLE
fixed security issue with shell=True

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -19,8 +19,7 @@ To run containerized Kraken as a Kubernetes/OpenShift Deployment, follow these s
     - In Kubernetes, use `kubectl config set-context --current --namespace=<namespace>`
     - In OpenShift, use `oc project <namespace>`
 4. Create a ConfigMap named kube-config using `kubectl create configmap kube-config --from-file=<path_to_kubeconfig>` *(eg. ~/.kube/config)*\
-***NOTE:** your kubeconfig might contain several cluster contexts and credentials so be sure, before creating the ConfigMap, to keep **only** the credentials related to the destination cluster. \
-Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more details*
+***NOTE:** your kubeconfig might contain several cluster contexts and credentials so be sure, before creating the ConfigMap, to keep **only** the credentials related to the destination cluster. Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more details*
 1. Create a ConfigMap named kraken-config using `kubectl create configmap kraken-config --from-file=<path_to_kraken>/config`
 2. Create a ConfigMap named scenarios-config using `kubectl create configmap scenarios-config --from-file=<path_to_kraken>/scenarios` 
 3. Create a ConfigMap named scenarios-openshift-config using `kubectl create configmap scenarios-openshift-config --from-file=<path_to_kraken>/scenarios/openshift`
@@ -28,7 +27,7 @@ Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/
 ***NOTE**: both the scenarios ConfigMaps are needed regardless you're running kraken in Kubernetes or OpenShift*
 9.  Create a service account to run the kraken pod `kubectl create serviceaccount useroot`.
 10. In Openshift, add privileges to service account and execute `oc adm policy add-scc-to-user privileged -z useroot`.\
-***NOTE**: to add privileges to the service account you must be logged in the cluster with an highly privileged account (ideally kubeadmin)*
+***NOTE:** to add privileges to the service account you must be logged in the cluster with an highly privileged account (ideally kubeadmin)*
 11. Create a Job using `kubectl apply -f <path_to_kraken>/containers/kraken.yml` and monitor the status using `oc get jobs` and `oc get pods`.
 
-***NOTE**: It is not generally recommended to run Kraken internal to the cluster as the pod which is running Kraken might get disrupted, the suggested use case to run kraken from inside k8s/OpenShift is to target **another** cluster (eg. to bypass network restrictions or to leverage cluster's computational resources)*
+***NOTE:** It is not generally recommended to run Kraken internal to the cluster as the pod which is running Kraken might get disrupted, the suggested use case to run kraken from inside k8s/OpenShift is to target **another** cluster (eg. to bypass network restrictions or to leverage cluster's computational resources)*

--- a/containers/README.md
+++ b/containers/README.md
@@ -18,13 +18,17 @@ To run containerized Kraken as a Kubernetes/OpenShift Deployment, follow these s
 3. Switch to `<namespace>` namespace:
     - In Kubernetes, use `kubectl config set-context --current --namespace=<namespace>`
     - In OpenShift, use `oc project <namespace>`
-4. Create a ConfigMap named kube-config using `kubectl create configmap kube-config --from-file=<path_to_kubeconfig>`
-5. Create a ConfigMap named kraken-config using `kubectl create configmap kraken-config --from-file=<path_to_kraken_config>`
-6. Create a ConfigMap named scenarios-config using `kubectl create configmap scenarios-config --from-file=<path_to_scenarios_folder>`
-7. Create a ConfigMap named scenarios-openshift-config using `kubectl create configmap scenarios-openshift-config --from-file=<path_to_scenarios_openshift_folder>`
-8. Create a ConfigMap named scenarios-kube-config using `kubectl create configmap scenarios-kube-config --from-file=<path_to_scenarios_kube_folder>`
-9. Create a service account to run the kraken pod `kubectl create serviceaccount useroot`.
-10. In Openshift, add privileges to service account and execute `oc adm policy add-scc-to-user privileged -z useroot`.
-11. Create a Job using `kubectl apply -f kraken.yml` and monitor the status using `oc get jobs` and `oc get pods`.
+4. Create a ConfigMap named kube-config using `kubectl create configmap kube-config --from-file=<path_to_kubeconfig>` *(eg. ~/.kube/config)*\
+***NOTE:** your kubeconfig might contain several cluster contexts and credentials so be sure, before creating the ConfigMap, to keep **only** the credentials related to the destination cluster. \
+Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more details*
+1. Create a ConfigMap named kraken-config using `kubectl create configmap kraken-config --from-file=<path_to_kraken>/config`
+2. Create a ConfigMap named scenarios-config using `kubectl create configmap scenarios-config --from-file=<path_to_kraken>/scenarios` 
+3. Create a ConfigMap named scenarios-openshift-config using `kubectl create configmap scenarios-openshift-config --from-file=<path_to_kraken>/scenarios/openshift`
+4. Create a ConfigMap named scenarios-kube-config using `kubectl create configmap scenarios-kube-config --from-file=<path_to_kraken>/scenarios/kube` \
+***NOTE**: both the scenarios ConfigMaps are needed regardless you're running kraken in Kubernetes or OpenShift*
+9.  Create a service account to run the kraken pod `kubectl create serviceaccount useroot`.
+10. In Openshift, add privileges to service account and execute `oc adm policy add-scc-to-user privileged -z useroot`.\
+***NOTE**: to add privileges to the service account you must be logged in the cluster with an highly privileged account (ideally kubeadmin)*
+11. Create a Job using `kubectl apply -f <path_to_kraken>/containers/kraken.yml` and monitor the status using `oc get jobs` and `oc get pods`.
 
-NOTE: It is not recommended to run Kraken internal to the cluster as the pod which is running Kraken might get disrupted.
+***NOTE**: It is not generally recommended to run Kraken internal to the cluster as the pod which is running Kraken might get disrupted, the suggested use case to run kraken from inside k8s/OpenShift is to target **another** cluster (eg. to bypass network restrictions or to leverage cluster's computational resources)*

--- a/kraken/invoke/command.py
+++ b/kraken/invoke/command.py
@@ -1,13 +1,20 @@
 import subprocess
 import logging
 import sys
-
+import shlex
 
 # Invokes a given command and returns the stdout
+
+
 def invoke(command, timeout=None):
     output = ""
+    command = shlex.split(command)
+    if "&&" in command or "||" in command or "|" in command:
+        raise Exception(
+            "Chaining or piping commands is not supported")
     try:
-        output = subprocess.check_output(command, shell=True, universal_newlines=True, timeout=timeout)
+        output = subprocess.check_output(
+            command, shell=False, universal_newlines=True, timeout=timeout)
     except Exception as e:
         logging.error("Failed to run %s, error: %s" % (command, e))
         sys.exit(1)
@@ -17,8 +24,13 @@ def invoke(command, timeout=None):
 # Invokes a given command and returns the stdout
 def invoke_no_exit(command, timeout=None):
     output = ""
+    command = shlex.split(command)
+    if "&&" in command or "||" in command or "|" in command:
+        raise Exception(
+            "Chaining or piping commands is not supported")
     try:
-        output = subprocess.check_output(command, shell=True, universal_newlines=True, timeout=timeout)
+        output = subprocess.check_output(
+            command, shell=False, universal_newlines=True, timeout=timeout)
         logging.info("output " + str(output))
     except Exception as e:
         logging.error("Failed to run %s, error: %s" % (command, e))
@@ -27,7 +39,12 @@ def invoke_no_exit(command, timeout=None):
 
 
 def run(command):
+    command = shlex.split(command)
     try:
-        subprocess.run(command, shell=True, universal_newlines=True, timeout=45)
+        if "&&" in command or "||" in command or "|" in command:
+            raise Exception(
+                "Chaining or piping commands is not supported")
+        subprocess.run(command, shell=False,
+                       universal_newlines=True, timeout=45)
     except Exception:
         pass

--- a/kraken/performance_dashboards/setup.py
+++ b/kraken/performance_dashboards/setup.py
@@ -2,25 +2,36 @@ import subprocess
 import logging
 import git
 import sys
-
+import shutil
 
 # Installs a mutable grafana on the Kubernetes/OpenShift cluster and loads the performance dashboards
+
+
 def setup(repo, distribution):
+    workdir = "performance-dashboards/dittybopper"
     if distribution == "kubernetes":
-        command = "cd performance-dashboards/dittybopper && ./k8s-deploy.sh"
+        command = "./k8s-deploy.sh"
     elif distribution == "openshift":
-        command = "cd performance-dashboards/dittybopper && ./deploy.sh"
+        command = "./deploy.sh"
     else:
-        logging.error("Provided distribution: %s is not supported" % (distribution))
+        logging.error("Provided distribution: %s is not supported" %
+                      (distribution))
         sys.exit(1)
-    delete_repo = "rm -rf performance-dashboards || exit 0"
-    logging.info("Cloning, installing mutable grafana on the cluster and loading the dashboards")
+    logging.info(
+        "Cloning, installing mutable grafana on the cluster and loading the dashboards")
     try:
         # delete repo to clone the latest copy if exists
-        subprocess.run(delete_repo, shell=True, universal_newlines=True, timeout=45)
+        try:
+            shutil.rmtree("performance-dashboards")
+        except Exception as e:
+            logging.warn(
+                "Failed to remove folder: %s" % (e))
         # clone the repo
         git.Repo.clone_from(repo, "performance-dashboards")
         # deploy performance dashboards
-        subprocess.run(command, shell=True, universal_newlines=True)
+        subprocess.run(command, shell=False, cwd=workdir,
+                       universal_newlines=True)
+
     except Exception as e:
-        logging.error("Failed to install performance-dashboards, error: %s" % (e))
+        logging.error(
+            "Failed to install performance-dashboards, error: %s" % (e))

--- a/scenarios/openshift/command_runner.py
+++ b/scenarios/openshift/command_runner.py
@@ -1,0 +1,44 @@
+import subprocess
+import shlex
+import logging
+
+class CommandRunner:
+    @staticmethod
+    #runs shell commands supporting piping without using shell=True
+    def run(cmd):
+        if "|" in cmd:
+            commands_list = cmd.split('|')
+        else:
+            commands_list = []
+            commands_list.append(cmd)
+        i = 0
+        process_handlers = {}
+        try:
+            for command in commands_list:
+                command = command.strip()
+                if i == 0:
+                    process_handlers[i] = subprocess.Popen(shlex.split(command.strip(
+                    )), shell=False, stdin=None, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                else:
+                    process_handlers[i] = subprocess.Popen(shlex.split(command.strip(
+                    )), shell=False, stdin=process_handlers[i-1].stdout, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                i = i + 1
+            (output, _) = process_handlers[i-1].communicate()
+            process_handlers[0].wait()
+        except Exception as e:
+            logging.error("Failed to run %s, error: %s" % (cmd, e))
+        return output
+
+
+
+
+def run(cmd):
+    try:
+        output = subprocess.Popen(
+            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        (out, err) = output.communicate()
+    except Exception as e:
+        logging.error("Failed to run %s, error: %s" % (cmd, e))
+    return out
+

--- a/scenarios/openshift/command_runner.py
+++ b/scenarios/openshift/command_runner.py
@@ -28,17 +28,3 @@ class CommandRunner:
         except Exception as e:
             logging.error("Failed to run %s, error: %s" % (cmd, e))
         return output
-
-
-
-
-def run(cmd):
-    try:
-        output = subprocess.Popen(
-            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-    except Exception as e:
-        logging.error("Failed to run %s, error: %s" % (cmd, e))
-    return out
-

--- a/scenarios/openshift/post_action_etcd_container.py
+++ b/scenarios/openshift/post_action_etcd_container.py
@@ -2,22 +2,12 @@
 import subprocess
 import logging
 import time
-
-
-def run(cmd):
-    try:
-        output = subprocess.Popen(
-            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-    except Exception as e:
-        logging.error("Failed to run %s, error: %s" % (cmd, e))
-    return out
+from command_runner import CommandRunner
 
 
 i = 0
 while i < 100:
-    pods_running = run("oc get pods -n openshift-etcd -l app=etcd | grep -c '4/4'").rstrip()
+    pods_running = CommandRunner.run("oc get pods -n openshift-etcd -l app=etcd | grep -c '4/4'").rstrip()
     if pods_running == "3":
         break
     time.sleep(5)

--- a/scenarios/openshift/post_action_etcd_example_py.py
+++ b/scenarios/openshift/post_action_etcd_example_py.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python3
 import subprocess
 import logging
+from command_runner import CommandRunner
 
 
-def run(cmd):
-    try:
-        output = subprocess.Popen(
-            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-        logging.info("out " + str(out))
-    except Exception as e:
-        logging.error("Failed to run %s, error: %s" % (cmd, e))
-    return out
-
-
-pods_running = run("oc get pods -n openshift-etcd | grep -c Running").rstrip()
+pods_running = CommandRunner.run("oc get pods -n openshift-etcd | grep -c Running").rstrip()
 
 if pods_running == str(3):
     print("There were 3 pods running properly")

--- a/scenarios/openshift/post_action_namespace.py
+++ b/scenarios/openshift/post_action_namespace.py
@@ -1,22 +1,12 @@
 #!/usr/bin/env python3
 import subprocess
 import time
-
-
-def run(cmd):
-    try:
-        output = subprocess.Popen(
-            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-    except Exception as e:
-        print("Failed to run %s, error: %s" % (cmd, e))
-    return out
+from command_runner import CommandRunner
 
 
 i = 0
 while i < 100:
-    projects_active = run("oc get project | grep 'ingress' | grep -c Active").rstrip()
+    projects_active = CommandRunner.run("oc get project | grep 'ingress' | grep -c Active").rstrip()
     if projects_active == "3":
         break
     i += 1

--- a/scenarios/openshift/post_action_regex.py
+++ b/scenarios/openshift/post_action_regex.py
@@ -3,7 +3,7 @@ import logging
 import re
 import subprocess
 import sys
-
+from command_runner import CommandRunner
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
@@ -56,27 +56,13 @@ def check_namespaces(namespaces):
         sys.exit(1)
 
 
-def run(cmd):
-    try:
-        output = subprocess.Popen(
-            cmd,
-            shell=True,
-            universal_newlines=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-    except Exception as e:
-        logging.error("Failed to run %s, error: %s", cmd, e)
-    return out
-
 
 def print_running_pods():
     regex_namespace_list = ["openshift-.*"]
     checked_namespaces = check_namespaces(regex_namespace_list)
     pods_running = 0
     for namespace in checked_namespaces:
-        new_pods_running = run(
+        new_pods_running = CommandRunner.run(
             "oc get pods -n " + namespace + " | grep -c Running"
         ).rstrip()
         try:

--- a/scenarios/openshift/post_action_shut_down.py
+++ b/scenarios/openshift/post_action_shut_down.py
@@ -3,23 +3,12 @@ import subprocess
 import logging
 import time
 import yaml
-
-
-def run(cmd):
-    out = ""
-    try:
-        output = subprocess.Popen(
-            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
-        (out, err) = output.communicate()
-    except Exception as e:
-        logging.info("Failed to run %s, error: %s" % (cmd, e))
-    return out
+from command_runner import CommandRunner
 
 
 # Get cluster operators and return yaml
 def get_cluster_operators():
-    operators_status = run("kubectl get co -o yaml")
+    operators_status = CommandRunner.run("kubectl get co -o yaml")
     status_yaml = yaml.safe_load(operators_status, Loader=yaml.FullLoader)
     return status_yaml
 
@@ -59,18 +48,18 @@ while len(failed_operators) > 0:
         exit(1)
     counter += wait_duration
 
-not_ready = run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
+not_ready = CommandRunner.run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
 while int(not_ready) > 0:
     time.sleep(wait_duration)
-    not_ready = run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
+    not_ready = CommandRunner.run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
     if counter >= timeout:
         print("Nodes are still not ready after " + str(timeout) + "seconds")
         exit(1)
     counter += wait_duration
 
-worker_nodes = run("oc get nodes --no-headers | grep worker | egrep -v NotReady | awk '{print $1}'").rstrip()
+worker_nodes = CommandRunner.run("oc get nodes --no-headers | grep worker | egrep -v NotReady | awk '{print $1}'").rstrip()
 print("Worker nodes list \n" + str(worker_nodes))
-master_nodes = run("oc get nodes --no-headers | grep master | egrep -v NotReady | awk '{print $1}'").rstrip()
+master_nodes = CommandRunner.run("oc get nodes --no-headers | grep master | egrep -v NotReady | awk '{print $1}'").rstrip()
 print("Master nodes list \n" + str(master_nodes))
-infra_nodes = run("oc get nodes --no-headers | grep infra | egrep -v NotReady | awk '{print $1}'").rstrip()
+infra_nodes = CommandRunner.run("oc get nodes --no-headers | grep infra | egrep -v NotReady | awk '{print $1}'").rstrip()
 print("Infra nodes list \n" + str(infra_nodes))


### PR DESCRIPTION
issue redhat-chaos/krkn#360  
Fixed the shell=True security issue in subprocess calls. In the scenarios folder I created the class CommandRunner with a static method to centralize the run command (before was duplicated in every script); this method supports command piping.
As discussed with @chaitanyaenr in invoke/command.py if the command strings contains "&&" or "||" or "|" an exception is raised.
In performance_dashboards/setup.py I add the cwd param (working dir)  in the subprocess.run in order to remove the chaining in the command and I changed the "rm -rf ...." with a shutil.rmtree in order to remove the or operator in the command.