### PR TITLE
check user's authorization before running functional tests

### DIFF
--- a/.github/users.txt
+++ b/.github/users.txt
@@ -1,0 +1,6 @@
+tsebastiani
+paigerube14
+chaitanyaenr
+sandrobonazzola
+yogananth-subramanian
+janosdebugs

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -1,11 +1,32 @@
 on: issue_comment
 
 jobs:
+  check_user:
+    # This job only runs for pull request comments
+    name: Check User's Authorization
+    if: contains(github.event.comment.body, '/test') && contains(github.event.comment.html_url, '/pull/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Kraken
+        uses: actions/checkout@v3
+      - name: Check User's Authorization
+        run: |
+          for name in `cat .github/users.txt`
+          do 
+            if [ $name == "${{github.event.sender.login}}" ]
+            then
+              exit 0
+            fi
+          done
+          echo "user ${{github.event.sender.login}} is not allowed to run functional tests Action"
+          exit 1
   pr_commented:
     # This job only runs for pull request comments containing /functional
     name: Functional Tests
     if: contains(github.event.comment.body, '/test') && contains(github.event.comment.html_url, '/pull/') && github.event.requested_team.name == 'redhat-chaos'
     runs-on: ubuntu-latest
+    needs:
+      - check_user
     steps:
       - name: Check out Kraken
         uses: actions/checkout@v3


### PR DESCRIPTION
This simple mechanism prevents that the functional tests github action is run by someone outside the team. The Action looks for the username that issued the comment into a file in the repo (.github/users.txt) and, if it's not found, the action is skipped. Separated in two different jobs to avoid Functional Test post action to be run. In order to add more users we just need to add the github handle to the users.txt file. If I forgot someone I'm really sorry please write me on slack and I'll add to the list.