### PR TITLE
check user's authorization before running functional tests

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -1,11 +1,35 @@
 on: issue_comment
 
 jobs:
+  check_user:
+    # This job only runs for pull request comments
+    name: Check User Authorization
+    env:
+      USERS: ${{vars.USERS}}
+    if: contains(github.event.comment.body, '/test') && contains(github.event.comment.html_url, '/pull/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check User
+        run: |
+          for name in `echo $USERS`
+          do 
+            name="${name//$'\r'/}"
+            name="${name//$'\n'/}"
+            if [ $name == "${{github.event.sender.login}}" ]
+            then
+              echo "user ${{github.event.sender.login}} authorized, action started..."
+              exit 0
+            fi
+          done
+          echo "user ${{github.event.sender.login}} is not allowed to run functional tests Action"
+          exit 1
   pr_commented:
     # This job only runs for pull request comments containing /functional
     name: Functional Tests
     if: contains(github.event.comment.body, '/test') && contains(github.event.comment.html_url, '/pull/') && github.event.requested_team.name == 'redhat-chaos'
     runs-on: ubuntu-latest
+    needs:
+      - check_user
     steps:
       - name: Check out Kraken
         uses: actions/checkout@v3


### PR DESCRIPTION
Added a job that checks users authorization before running functional tests pipeline. The users list is contained on the repo's environment variable `$USERS`  (here a [guide](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) on how to set variables). Users can be added and removed simply modifying this variable. The check is performed in a separated job in order to not run any part of the Functional test pipeline and skip before.
this users are already added:
|Username|
|---|
|tsebastiani|
|paigerube14|
|chaitanyaenr|
|sandrobonazzola|
|yogananth-subramanian|
|janosdebugs|

whoever has access to the repo settings can add or remove users.