### PR TITLE
kill-pod plugin dependency pointing to specific commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ arcaflow-plugin-sdk>=0.9.0
 wheel
 service_identity
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-git+https://github.com/arcalot/arcaflow-plugin-kill-pod.git@main
+git+https://github.com/redhat-chaos/arcaflow-plugin-kill-pod.git@c406307329b07d4077e85e4e615b3bb133f20144
 arcaflow >= 0.3.0


### PR DESCRIPTION
Temporarly pointing to kill-pod plugin specific commit in order to avoid breaking change with new arcaflow lib kubernetes API. This will be removed once the new arcaflow architecture will be fully merged.