### PR TITLE
Add missing parameters supported by container scenarios

### DIFF
--- a/docs/container_scenarios.md
+++ b/docs/container_scenarios.md
@@ -14,7 +14,9 @@ scenarios:
   container_name: "<specific container name>"  # This is optional, can take out and will kill all containers in all pods found under namespace and label
   pod_names:  # This is optional, can take out and will select all pods with given namespace and label
   - <pod_name>
-  retry_wait: <number of seconds to wait for container to be running again> (defaults to 120seconds)
+  count: <number of containers to disrupt, default=1>
+  action: <Action to run. For example kill 1 ( hang up ) or kill 9. Default is set to kill 1>
+  expected_recovery_time: <number of seconds to wait for container to be running again> (defaults to 120seconds)
 ```
 
 #### Post Action
@@ -34,5 +36,5 @@ See [scenarios/post_action_etcd_container.py](https://github.com/redhat-chaos/kr
 containers that were killed as well as the namespaces and pods to verify all containers that were affected recover properly.
 
 ```
-retry_wait: <seconds to wait for container to recover>
+expected_recovery_time: <seconds to wait for container to recover>
 ```

--- a/scenarios/openshift/container_etcd.yml
+++ b/scenarios/openshift/container_etcd.yml
@@ -5,4 +5,4 @@ scenarios:
   container_name: "etcd"
   action: "kill 1"
   count: 1
-  retry_wait: 60
+  expected_recovery_time: 60


### PR DESCRIPTION
Also renames retry_wait to expected_recovery_time to make it clear that the Kraken will exit 1 if the container doesn't recover within the expected time.
Fixes https://github.com/redhat-chaos/krkn/issues/414