### PR TITLE
Kraken is pointing to a buggy kill-pod plugin implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ arcaflow-plugin-sdk>=0.9.0
 wheel
 service_identity
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-git+https://github.com/redhat-chaos/arcaflow-plugin-kill-pod.git@c406307329b07d4077e85e4e615b3bb133f20144
+git+https://github.com/redhat-chaos/arcaflow-plugin-kill-pod.git@572e50ad4291a29c886af8312b88ca0766f79da2
+
 arcaflow >= 0.3.0
 prometheus_api_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ arcaflow-plugin-sdk>=0.9.0
 wheel
 service_identity
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-git+https://github.com/redhat-chaos/arcaflow-plugin-kill-pod.git@572e50ad4291a29c886af8312b88ca0766f79da2
+git+https://github.com/redhat-chaos/arcaflow-plugin-kill-pod.git
 
 arcaflow >= 0.3.0
 prometheus_api_client


### PR DESCRIPTION
the current kill-pod plugin implementation that is pointed by the requirements.txt in the main branch doesn't configure the kubernetes client with the kubeconfig passed by the configuration [here an example](https://github.com/redhat-chaos/arcaflow-plugin-kill-pod/blob/c406307329b07d4077e85e4e615b3bb133f20144/arcaflow_plugin_kill_pod.py#L279). Unfortunately the current implementation has a breaking change in the plugin interface, so in order to keep the compatibility until the arcaflow integration is merged, is to point to a [compatibility branch](https://github.com/redhat-chaos/arcaflow-plugin-kill-pod/tree/no_arca_compat) in the arcaflow-plugin repo.