### PR TITLE
Allow kraken to run with environment variables instead of kubeconfig file

### DIFF
--- a/kraken/kubernetes/client.py
+++ b/kraken/kubernetes/client.py
@@ -24,13 +24,17 @@ def initialize_clients(kubeconfig_path):
     global dyn_client
     global custom_object_client
     try:
-        config.load_kube_config(kubeconfig_path)
+        if kubeconfig_path:
+            config.load_kube_config(kubeconfig_path)
+            k8s_client = config.new_client_from_config(config_file=kubeconfig_path)
+        else:
+            config.load_incluster_config()
+            k8s_client = None
         api_client = client.ApiClient()
-        k8s_client = config.new_client_from_config(config_file=kubeconfig_path)
         cli = client.CoreV1Api(k8s_client)
         batch_cli = client.BatchV1Api(k8s_client)
         custom_object_client = client.CustomObjectsApi(k8s_client)
-        dyn_client = DynamicClient(k8s_client)
+        dyn_client = DynamicClient(api_client)
         watch_resource = watch.Watch()
     except ApiException as e:
         logging.error("Failed to initialize kubernetes client: %s\n" % e)

--- a/kraken/kubernetes/client.py
+++ b/kraken/kubernetes/client.py
@@ -26,10 +26,8 @@ def initialize_clients(kubeconfig_path):
     try:
         if kubeconfig_path:
             config.load_kube_config(kubeconfig_path)
-            k8s_client = config.new_client_from_config(config_file=kubeconfig_path)
         else:
             config.load_incluster_config()
-            k8s_client = None
         api_client = client.ApiClient()
         cli = client.CoreV1Api(api_client)
         batch_cli = client.BatchV1Api(api_client)

--- a/kraken/kubernetes/client.py
+++ b/kraken/kubernetes/client.py
@@ -31,9 +31,9 @@ def initialize_clients(kubeconfig_path):
             config.load_incluster_config()
             k8s_client = None
         api_client = client.ApiClient()
-        cli = client.CoreV1Api(k8s_client)
-        batch_cli = client.BatchV1Api(k8s_client)
-        custom_object_client = client.CustomObjectsApi(k8s_client)
+        cli = client.CoreV1Api(api_client)
+        batch_cli = client.BatchV1Api(api_client)
+        custom_object_client = client.CustomObjectsApi(api_client)
         dyn_client = DynamicClient(api_client)
         watch_resource = watch.Watch()
     except ApiException as e:

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -91,7 +91,8 @@ def main(cfg):
         check_critical_alerts = config["performance_monitoring"].get("check_critical_alerts", False)                          
 
         # Initialize clients
-        if not os.path.isfile(kubeconfig_path):
+        if (not os.path.isfile(kubeconfig_path) and
+            not os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/token")):
             logging.error(
                 "Cannot read the kubeconfig file at %s, please check" % kubeconfig_path
             )

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -98,8 +98,12 @@ def main(cfg):
             )
             sys.exit(1)
         logging.info("Initializing client to talk to the Kubernetes cluster")
-        os.environ["KUBECONFIG"] = str(kubeconfig_path)
-        kubecli.initialize_clients(kubeconfig_path)
+        try:
+            kubeconfig_path
+            os.environ["KUBECONFIG"] = str(kubeconfig_path)
+            kubecli.initialize_clients(kubeconfig_path)
+        except NameError:
+            kubecli.initialize_clients(None)
 
         # find node kraken might be running on
         kubecli.find_kraken_node()


### PR DESCRIPTION
This PR allows krkn to be run inside a k8s cluster using environment variables instead of a kubeconfig file.