### PR TITLE
Change the severity of the etcd leader election check to warning

### DIFF
--- a/config/alerts
+++ b/config/alerts
@@ -8,4 +8,4 @@
 
 - expr: increase(etcd_server_leader_changes_seen_total[2m]) > 0
   description: etcd leader changes observed
-  severity: critical
+  severity: error


### PR DESCRIPTION
This is the first step towards the goal to only have metrics tracking the overall health and performance of the component/cluster. For instance, for etcd disruption scenarios, leader elections are expected, we should instead track etcd leader availability and fsync latency under critical catergory vs leader elections.