### PR TITLE
Bump release version to v1.3.1

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=azure-cli /usr/local/bin/az /usr/bin/az
 RUN yum install epel-release -y && \
     yum install -y git python39 python3-pip jq gettext && \
     python3.9 -m pip install -U pip && \
-    git clone https://github.com/redhat-chaos/krkn.git --branch v1.3.0 /root/kraken && \
+    git clone https://github.com/redhat-chaos/krkn.git --branch v1.3.1 /root/kraken && \
     mkdir -p /root/.kube && cd /root/kraken && \
     pip3.9 install -r requirements.txt
 


### PR DESCRIPTION
This updates the Krkn container images to use the latest v1.3.1 minor release: https://github.com/redhat-chaos/krkn/releases.