### PR TITLE
Switch from centos to redhat ubi base image

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/openshift/origin-tests:latest as origintests
 
 FROM mcr.microsoft.com/azure-cli:latest as azure-cli
 
-FROM quay.io/centos/centos:stream9
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL org.opencontainers.image.authors="Red Hat OpenShift Chaos Engineering"
 
@@ -14,8 +14,7 @@ ENV KUBECONFIG /root/.kube/config
 COPY --from=azure-cli /usr/local/bin/az /usr/bin/az
 
 # Install dependencies
-RUN yum install epel-release -y && \
-    yum install -y git python39 python3-pip jq gettext wget && \
+RUN yum install -y git python39 python3-pip jq gettext wget && \
     python3.9 -m pip install -U pip && \
     git clone https://github.com/redhat-chaos/krkn.git --branch v1.3.3 /root/kraken && \
     mkdir -p /root/.kube && cd /root/kraken && \


### PR DESCRIPTION
This replaces the base image for Kraken container images to use redhat ubi image to be more secure and stable.