### PR TITLE
Bake in virtualenv in krkn images

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -17,6 +17,7 @@ RUN yum install -y git python39 python3-pip jq gettext wget && \
     git clone https://github.com/redhat-chaos/krkn.git --branch v1.3.5 /root/kraken && \
     mkdir -p /root/.kube && cd /root/kraken && \
     pip3.9 install -r requirements.txt && \
+    pip3.9 install virtualenv && \
     wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
 
 # Get Kubernetes and OpenShift clients from stable releases

--- a/containers/Dockerfile-ppc64le
+++ b/containers/Dockerfile-ppc64le
@@ -17,6 +17,7 @@ RUN yum install -y git python39 python3-pip jq gettext wget && \
     git clone https://github.com/redhat-chaos/krkn.git --branch v1.3.5 /root/kraken && \
     mkdir -p /root/.kube && cd /root/kraken && \
     pip3.9 install -r requirements.txt && \
+    pip3.9 install virtualenv && \
     wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
 
 # Get Kubernetes and OpenShift clients from stable releases


### PR DESCRIPTION
This is needed to tie the python version being used in case multiple versions are installed.