### PR TITLE
Use images tagged with a release for hog scenarios

### DIFF
--- a/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
@@ -64,7 +64,7 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.2.0
     step: workload
     input:
       StressNGParams:

--- a/scenarios/arcaflow/memory-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/memory-hog/sub-workflow.yaml
@@ -56,7 +56,7 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:latest
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.2.0
     step: workload
     input:
       StressNGParams:


### PR DESCRIPTION
This commit switches from using latest images to a specific release to review changes and update configs before using the latest bits.