### PR TITLE
update to plugin release stressng:0.3.0

### DIFF
--- a/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
@@ -64,13 +64,13 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.2.0
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.0
     step: workload
     input:
+      cleanup: "true"
       StressNGParams:
         timeout: !expr $.input.duration
-        cleanup: "true"
-        items:
+        stressors:
           - stressor: cpu
             cpu_count: !expr $.input.cpu_count
             cpu_method: !expr $.input.cpu_method

--- a/scenarios/arcaflow/memory-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/memory-hog/sub-workflow.yaml
@@ -56,13 +56,13 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.2.0
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.0
     step: workload
     input:
+      cleanup: "true"
       StressNGParams:
         timeout: !expr $.input.duration
-        cleanup: "true"
-        items:
+        stressors:
           - stressor: vm
             vm: !expr $.input.vm_workers
             vm_bytes: !expr $.input.vm_bytes


### PR DESCRIPTION
The stressng plugin was updated this week to 0.3.0, bringing an updated stress-ng release and minor changes to the input schema. Update the hog scenario workflows to use the new plugin release.