### PR TITLE
bump arcaflow stressng plugin to 0.3.1 for bug fix

### DIFF
--- a/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
@@ -64,7 +64,7 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.0
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.1
     step: workload
     input:
       cleanup: "true"

--- a/scenarios/arcaflow/memory-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/memory-hog/sub-workflow.yaml
@@ -56,7 +56,7 @@ steps:
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.0
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.1
     step: workload
     input:
       cleanup: "true"


### PR DESCRIPTION
Bumping arcaflow stressng plugin to 0.3.1 to pick up a bug fix that will correct silent workflow failures.