### PR TITLE
io-hog working configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,7 @@ kraken:
         - arcaflow_scenarios:
             - scenarios/arcaflow/cpu-hog/input.yaml
             - scenarios/arcaflow/memory-hog/input.yaml
+            - scenarios/arcaflow/io-hog/input.yaml
         - application_outages:
             - scenarios/openshift/app_outage.yaml
         - container_scenarios:                             # List of chaos pod scenarios to load

--- a/scenarios/arcaflow/io-hog/config.yaml
+++ b/scenarios/arcaflow/io-hog/config.yaml
@@ -1,0 +1,10 @@
+deployer:
+  connection: {}
+  type: kubernetes
+log:
+  level: debug
+logged_outputs:
+  error:
+    level: error
+  success:
+    level: debug

--- a/scenarios/arcaflow/io-hog/input.yaml
+++ b/scenarios/arcaflow/io-hog/input.yaml
@@ -1,0 +1,13 @@
+input_list:
+- duration: 30s
+  io_block_size: 1m
+  io_workers: 1
+  io_write_bytes: 10m
+  kubeconfig: ''
+  namespace: default
+  node_selector: {}
+  target_pod_folder: /hog-data
+  target_pod_volume:
+    hostPath:
+      path: /tmp
+    name: node-volume

--- a/scenarios/arcaflow/io-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/io-hog/sub-workflow.yaml
@@ -1,0 +1,138 @@
+input:
+  root: RootObject
+  objects:
+    RootObject:
+      id: RootObject
+      properties:
+        kubeconfig:
+          display:
+            description: The complete kubeconfig file as a string
+            name: Kubeconfig file contents
+          type:
+            type_id: string
+          required: true
+        namespace:
+          display:
+            description: The namespace where the container will be deployed
+            name: Namespace
+          type:
+            type_id: string
+          required: true
+        node_selector:
+            display:
+              description: kubernetes node name where the plugin must be deployed
+            type:
+              type_id: map
+              values:
+                type_id: string
+              keys:
+                type_id: string
+            required: true
+        duration:
+          display:
+            name: duration the scenario expressed in seconds
+            description: stop  stress  test  after  T  seconds.  One  can  also specify the units of time in
+              seconds, minutes, hours, days or years with the suffix s, m, h, d or  y
+          type:
+            type_id: string
+          required: true
+        io_workers:
+          display:
+            description: number of workers
+            name: start N workers continually writing, reading  and  removing  temporary  files
+          type:
+            type_id: integer
+          required: true
+        io_block_size:
+            display:
+              description: single write size
+              name: specify size of each write in bytes. Size can be from 1 byte to 4MB.
+            type:
+              type_id: string
+            required: true
+        io_write_bytes:
+          display:
+            description: Total number of bytes written
+            name: write  N  bytes for each hdd process, the default is 1 GB. One can specify the size
+              as % of free space on the file system or in units  of  Bytes,  KBytes,  MBytes  and
+              GBytes using the suffix b, k, m or g
+          type:
+            type_id: string
+          required: true
+        target_pod_folder:
+          display:
+            description: Target Folder
+            name: Folder in the pod where the test will be executed and the test files will be written
+          type:
+            type_id: string
+          required: true
+        target_pod_volume:
+          display:
+            name: kubernetes volume definition
+            description: the volume that will be attached to the pod. In order to stress
+                         the node storage only hosPath mode is currently supported
+          type:
+            type_id: object
+            id: k8s_volume
+            properties:
+              name:
+                display:
+                  description: name of the volume (must match the name in pod definition)
+                type:
+                  type_id: string
+                required: true
+              hostPath:
+                  display:
+                    description: hostPath options expressed as string map (key-value)
+                  type:
+                    type_id: map
+                    values:
+                      type_id: string
+                    keys:
+                      type_id: string
+                  required: true
+          required: true
+
+steps:
+  kubeconfig:
+    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+    input:
+      kubeconfig: !expr $.input.kubeconfig
+  stressng:
+    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.3.1
+    step: workload
+    input:
+      cleanup: "true"
+      StressNGParams:
+        timeout: !expr $.input.duration
+        workdir: !expr $.input.target_pod_folder
+        stressors:
+          - stressor: hdd
+            hdd: !expr $.input.io_workers
+            hdd_bytes: !expr $.input.io_write_bytes
+            hdd_write_size: !expr $.input.io_block_size
+
+    deploy:
+      type: kubernetes
+      connection: !expr $.steps.kubeconfig.outputs.success.connection
+      pod:
+        metadata:
+          namespace: !expr $.input.namespace
+          labels:
+            arcaflow: stressng
+        spec:
+          nodeSelector: !expr $.input.node_selector
+          pluginContainer:
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /hog-data
+                name: node-volume
+          volumes:
+            - !expr $.input.target_pod_volume
+
+outputs:
+  success:
+    stressng: !expr $.steps.stressng.outputs.success
+

--- a/scenarios/arcaflow/io-hog/workflow.yaml
+++ b/scenarios/arcaflow/io-hog/workflow.yaml
@@ -1,0 +1,113 @@
+input:
+  root: RootObject
+  objects:
+    RootObject:
+      id: RootObject
+      properties:
+        input_list:
+          type:
+            type_id: list
+            items:
+              id: input_item
+              type_id: object
+              properties:
+                kubeconfig:
+                  display:
+                    description: The complete kubeconfig file as a string
+                    name: Kubeconfig file contents
+                  type:
+                    type_id: string
+                  required: true
+                namespace:
+                  display:
+                    description: The namespace where the container will be deployed
+                    name: Namespace
+                  type:
+                    type_id: string
+                  required: true
+                node_selector:
+                  display:
+                    description: kubernetes node name where the plugin must be deployed
+                  type:
+                    type_id: map
+                    values:
+                      type_id: string
+                    keys:
+                      type_id: string
+                  required: true
+                duration:
+                  display:
+                    name: duration the scenario expressed in seconds
+                    description: stop  stress  test  after  T  seconds.  One  can  also specify the units of time in
+                      seconds, minutes, hours, days or years with the suffix s, m, h, d or  y
+                  type:
+                    type_id: string
+                  required: true
+                io_workers:
+                  display:
+                    description: number of workers
+                    name: start N workers continually writing, reading  and  removing  temporary  files
+                  type:
+                    type_id: integer
+                  required: true
+                io_block_size:
+                  display:
+                    description: single write size
+                    name: specify size of each write in bytes. Size can be from 1 byte to 4MB.
+                  type:
+                    type_id: string
+                  required: true
+                io_write_bytes:
+                  display:
+                    description: Total number of bytes written
+                    name: write  N  bytes for each hdd process, the default is 1 GB. One can specify the size
+                      as % of free space on the file system or in units  of  Bytes,  KBytes,  MBytes  and
+                      GBytes using the suffix b, k, m or g
+                  type:
+                    type_id: string
+                  required: true
+                target_pod_folder:
+                  display:
+                    description: Target Folder
+                    name: Folder in the pod where the test will be executed and the test files will be written
+                  type:
+                    type_id: string
+                  required: true
+                target_pod_volume:
+                  display:
+                    name: kubernetes volume definition
+                    description: the volume that will be attached to the pod. In order to stress
+                      the node storage only hosPath mode is currently supported
+                  type:
+                    type_id: object
+                    id: k8s_volume
+                    properties:
+                      name:
+                        display:
+                          description: name of the volume (must match the name in pod definition)
+                        type:
+                          type_id: string
+                        required: true
+                      hostPath:
+                        display:
+                          description: hostPath options expressed as string map (key-value)
+                        type:
+                          type_id: map
+                          values:
+                            type_id: string
+                          keys:
+                            type_id: string
+                        required: true
+                  required: true
+steps:
+  workload_loop:
+    kind: foreach
+    items: !expr $.input.input_list
+    workflow: sub-workflow.yaml
+    parallelism: 1000
+outputs:
+  success:
+    workloads: !expr $.steps.workload_loop.outputs.success.data
+
+
+


### PR DESCRIPTION
It works instantiating a privileged container mounting the hostPath (seems to be the only solution to r/w on the node filesystem). It works on Vanilla OCP (4.14.0-0.nightly-2023-09-07-211548) needs to be tested on prow.